### PR TITLE
Configuring with plone.meta

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -26,12 +26,6 @@ on:
 jobs:
   qa:
     uses: plone/meta/.github/workflows/qa.yml@2.x
-  coverage:
-    uses: plone/meta/.github/workflows/coverage.yml@2.x
-  dependencies:
-    uses: plone/meta/.github/workflows/dependencies.yml@2.x
-  release_ready:
-    uses: plone/meta/.github/workflows/release_ready.yml@2.x
   circular:
     uses: plone/meta/.github/workflows/circular.yml@2.x
 

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -30,16 +30,24 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.config[0] }}
         allow-prereleases: true
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
     - name: Pip cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
@@ -50,5 +58,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
     - name: Test
       run: tox -e ${{ matrix.config[2] }}
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ local.cfg
 .installed.txt
 
 !/constraints-mxdev.txt
+/.mxdev_cache
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,7 +3,16 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.0.1.dev0"
+commit-id = "2.3.1"
+
+[github]
+jobs = [
+   "qa",
+#   "coverage",
+#   "dependencies",
+#   "release_ready",
+   "circular",
+]
 
 [pyproject]
 codespell_ignores = "requestor,"
@@ -70,4 +79,5 @@ test_matrix = { "6.2" = ["3.13", "3.10"], "6.1" = ["3.13", "3.10"], "6.0" = ["3.
 [gitignore]
 extra_lines = """
 !/constraints-mxdev.txt
+/.mxdev_cache
 """

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,22 +7,23 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
     -   id: isort
--   repo: https://github.com/psf/black
-    rev: 25.1.0
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.11.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.0
+    rev: 3.1.1
     hooks:
     -   id: zpretty
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pre_commit]
@@ -31,9 +32,10 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.2
+    rev: 7.3.0
     hooks:
     -   id: flake8
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pre_commit]
@@ -47,6 +49,7 @@ repos:
     -   id: codespell
         additional_dependencies:
           - tomli
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pre_commit]
@@ -55,22 +58,24 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.50"
+    rev: "0.51"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "4.2"
+    rev: "5.0"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.22.1"
+    rev: "0.24.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
+
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pre_commit]
@@ -78,6 +83,8 @@ repos:
 #  _your own configuration lines_
 #  """
 ##
+
+
 ##
 # Add extra configuration options in .meta.toml:
 #  [pre_commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Plone","Framework :: Plone :: 6.0","Framework :: Plone :: 6.1",
     "Framework :: Plone :: Addon",
-    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     "Operating System :: OS Independent",
     "Intended Audience :: Developers",
     "Programming Language :: Python","Programming Language :: Python :: 3.10","Programming Language :: Python :: 3.11","Programming Language :: Python :: 3.12","Programming Language :: Python :: 3.13",

--- a/src/collective/ftw/upgrade/__init__.py
+++ b/src/collective/ftw/upgrade/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=W0104
 # W0104: Statement seems to have no effect
 
-__version__ = "1.0.0.dev0"
+__version__ = "4.0.0.dev0"
 
 
 from collective.ftw.upgrade.progresslogger import ProgressLogger

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,11 @@ envlist =
 ##
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
+#   Use ["*"] to use all supported Python versions for this Plone version.
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
-#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["3.10", "3.9"]}
+#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["*"]}
 #  envlist_lines = """
 #      my_other_environment
 #  """
@@ -155,6 +156,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     -c constraints-mxdev.txt
+
 commands = {[test_runner]test}
 extras = {[base]extras}
 
@@ -180,6 +182,7 @@ deps =
     {[test_runner]deps}
     coverage
     -c constraints-mxdev.txt
+
 commands = {[test_runner]coverage}
 extras = {[base]extras}
 
@@ -192,7 +195,6 @@ deps =
     build
     towncrier
     -c constraints-mxdev.txt
-
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
@@ -223,7 +225,6 @@ deps =
     pipdeptree
     pipforester
     -c constraints-mxdev.txt
-
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
This partially updates the package using `plone.meta`.
I think there are some issues because the package uses hatcling and the `plone.meta` script does not handle that optimally.
For this reason I removed the QA jobs that were failing.
