### PR TITLE
Allow zest.releaser to find the version file

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -71,6 +71,10 @@ dependencies_mappings = [
     """,
 ]
 dependencies_ignores = "['blessed','cgi','distutils','other.package']"
+extra_lines = """
+[tool.zest-releaser]
+python-file-with-version = "src/collective/ftw/upgrade/__init__.py"
+"""
 
 [tox]
 use_mxdev = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,3 +327,6 @@ ignore = [
 #  _your own configuration lines_
 #  """
 ##
+
+[tool.zest-releaser]
+python-file-with-version = "src/collective/ftw/upgrade/__init__.py"


### PR DESCRIPTION
The specified setting matches the lines:

```toml
[tool.hatch.version]
path = src/collective/ftw/upgrade/__init__.py
```

Fixes #11