### PR TITLE
Fix the installation profile title and add an uninstall profile

### DIFF
--- a/news/16.bugfix.md
+++ b/news/16.bugfix.md
@@ -1,0 +1,1 @@
+Fix the installation profile title and add an uninstall profile [ale-rt]

--- a/src/collective/ftw/upgrade/configure.zcml
+++ b/src/collective/ftw/upgrade/configure.zcml
@@ -18,10 +18,18 @@
 
   <genericsetup:registerProfile
       name="default"
-      title="ftw.upgrade"
+      title="collective.ftw.upgrade"
       description="An advanced upgrade control panel."
       provides="Products.GenericSetup.interfaces.EXTENSION"
       directory="profiles/default"
+      />
+
+  <genericsetup:registerProfile
+      name="uninstall"
+      title="collective.ftw.upgrade uninstall profile"
+      description="Uninstall profile for collective.ftw.upgrade."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/uninstall"
       />
 
   <adapter factory=".gatherer.UpgradeInformationGatherer" />

--- a/src/collective/ftw/upgrade/profiles/uninstall/browserlayer.xml
+++ b/src/collective/ftw/upgrade/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layers>
+
+  <layer name="collective.ftw.upgrade"
+         remove="True"
+  />
+
+</layers>

--- a/src/collective/ftw/upgrade/profiles/uninstall/controlpanel.xml
+++ b/src/collective/ftw/upgrade/profiles/uninstall/controlpanel.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object meta_type="Plone Control Panel Tool"
+        name="portal_controlpanel"
+>
+
+  <configlet action_id="Upgrades"
+             remove="True"
+  />
+
+</object>


### PR DESCRIPTION
Fixes #16

> [!NOTE]
This is based on #15 because it assumes the id of the browser layer to remove is `collective.ftw.upgrade`