### PR TITLE
Change directive namespace to collective.ftw.upgrade.

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ upgrade step definition syntax with these **advantages**:
 ```xml
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    xmlns:upgrade-step="http://namespaces.zope.org/collective.ftw.upgrade"
     i18n_domain="my.package">
 
     <include package="ftw.upgrade" file="meta.zcml" />
@@ -563,7 +563,7 @@ them with whitespace.
 ```xml
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    xmlns:upgrade-step="http://namespaces.zope.org/collective.ftw.upgrade"
     i18n_domain="my.package">
 
     <include package="ftw.upgrade" file="meta.zcml" />
@@ -1017,7 +1017,7 @@ sub-package:
 ```xml
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
+    xmlns:upgrade-step="http://namespaces.zope.org/collective.ftw.upgrade"
     i18n_domain="my.package">
 
     <include package="ftw.upgrade" file="meta.zcml" />

--- a/news/18.bugfix.md
+++ b/news/18.bugfix.md
@@ -1,0 +1,1 @@
+Change directive namespace to collective.ftw.upgrade. [mathias.leigmruber]

--- a/src/collective/ftw/upgrade/meta.zcml
+++ b/src/collective/ftw/upgrade/meta.zcml
@@ -3,7 +3,7 @@
     xmlns:meta="http://namespaces.zope.org/meta"
     >
 
-  <meta:directives namespace="http://namespaces.zope.org/ftw.upgrade">
+  <meta:directives namespace="http://namespaces.zope.org/collective.ftw.upgrade">
 
     <meta:directive
         name="importProfile"

--- a/src/collective/ftw/upgrade/tests/builders.py
+++ b/src/collective/ftw/upgrade/tests/builders.py
@@ -2,6 +2,7 @@ from collective.ftw.upgrade import UpgradeStep
 from collective.ftw.upgrade.directory import scaffold
 from ftw.builder import builder_registry
 from ftw.builder.utils import serialize_callable
+from ftw.builder.zcml import ZCMLBuilder
 from path import Path
 
 import inflection
@@ -14,6 +15,20 @@ class DeferrableUpgrade(UpgradeStep):
 
     def __call__(self):
         pass
+
+
+class FixedZCMLBuilder(ZCMLBuilder):
+
+    def generate(self):
+        # Fix hardcoded ftw.upgrade namespace in zcml builder
+        zcml = super().generate()
+        return zcml.replace(
+            "http://namespaces.zope.org/ftw.upgrade",
+            "http://namespaces.zope.org/collective.ftw.upgrade",
+        )
+
+
+builder_registry.register("zcml", FixedZCMLBuilder, force=True)
 
 
 class UpgradeStepBuilder:


### PR DESCRIPTION
Fixes #18 

@ale-rt In theory we could keep the old registration as well. But I think it makes sense to get rid of it. 

I had to fix the ftw.builder zml builder here. I cannot make a new release of ftw.builder. Probably a package I will tackle soon as well. 