### PR TITLE
Reimplement manage-uprades view displaying the actual result of the upgrade

### DIFF
--- a/news/20.feature.md
+++ b/news/20.feature.md
@@ -1,0 +1,1 @@
+Reimplement manage-uprades view displaying the actual result of the upgrade. [mathias.leimgruber]

--- a/src/collective/ftw/upgrade/browser/configure.zcml
+++ b/src/collective/ftw/upgrade/browser/configure.zcml
@@ -29,4 +29,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      name="upgrade-execute"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".manage.ExecuteUpgradesView"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/src/collective/ftw/upgrade/browser/resources/manage.css
+++ b/src/collective/ftw/upgrade/browser/resources/manage.css
@@ -86,14 +86,54 @@
   background-color: #F8CE92;
 }
 
-#upgrade-output {
-  width: 100%;
-  min-height: 500px;
-  border: 1px solid #eee;
+#upgrade-progress {
   display: none;
-  overflow: visible;
+  text-align: center;
+  padding: 2em;
+}
+
+#upgrade-progress p {
+  margin-top: 1em;
+  font-size: 1.1em;
+  color: #555;
+}
+
+.upgrade-spinner {
+  display: inline-block;
+  width: 40px;
+  height: 40px;
+  border: 4px solid #ddd;
+  border-top-color: #007bb1;
+  border-radius: 50%;
+  animation: upgrade-spin 0.8s linear infinite;
+}
+
+@keyframes upgrade-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#upgrade-output {
+  display: none;
+  width: 100%;
+  margin-top: 1em;
+}
+
+#upgrade-log {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  padding: 1em;
+  font-family: monospace;
+  font-size: 0.85em;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 1000px;
+  overflow-y: auto;
 }
 
 #back-to-upgrades {
   display: none;
+  margin-top: 1em;
 }

--- a/src/collective/ftw/upgrade/browser/resources/manage.js
+++ b/src/collective/ftw/upgrade/browser/resources/manage.js
@@ -1,18 +1,15 @@
 $(document).ready(function() {
-    // Clear all checkboxes when "Select None" is clicked
     $('.select-none').click(function(e) {
         e.preventDefault();
         $('.profiles input[type=checkbox]').prop('checked', false);
     });
 
-    // Select all addons yet to be installd
     $('.select-not-installed').click(function(e) {
         e.preventDefault();
         $('.profiles input[type=checkbox]').prop('checked', false);
         $('.profiles .upgrade.proposed input[type=checkbox]').prop('checked', true);
     });
 
-    // Show/hide addon's completed upgrades
     $('.profiles .profile-title strong').click(function(e){
         e.preventDefault();
         var profile = $(this).parents('.profile:first');
@@ -27,7 +24,6 @@ $(document).ready(function() {
         });
     });
 
-    // Check checkbox for upgrade step if upgrade name is clicked
     $('.profiles .upgrade').click(function(e) {
         if($(e.target).is('input[type=checkbox]')) {
             return;
@@ -36,20 +32,35 @@ $(document).ready(function() {
         checkbox.prop('checked', !checkbox.prop('checked'));
     });
 
-    // Hide the upgrade form while an upgrade is being installed
     $('#upgrade-form').submit(function(e) {
-        $(this).hide();
-        $('#back-to-upgrades').show();
+        e.preventDefault();
+        var $form = $(this);
+        $form.hide();
+        $('#upgrade-progress').show();
 
-        var height = ($('#portal-column-one').height() -
-                      $('#portal-column-content').height());
-        $('#upgrade-output').show();
-        if(height > 0) {
-            $('#upgrade-output').css('height', height);
-        }
+        $.ajax({
+            url: $form.attr('action'),
+            type: 'POST',
+            data: $form.serialize(),
+            dataType: 'text',
+            success: function(data) {
+                $('#upgrade-progress').hide();
+                $('#upgrade-log').text(data);
+                $('#upgrade-output').show();
+                $('#back-to-upgrades').show();
+            },
+            error: function(xhr) {
+                $('#upgrade-progress').hide();
+                $('#upgrade-log').text(
+                    'Error during upgrade execution:\n' +
+                    (xhr.responseText || 'Unknown error')
+                );
+                $('#upgrade-output').show();
+                $('#back-to-upgrades').show();
+            }
+        });
     });
 
-    // Allow user to return to the upgrades form after installing an upgrade
     $('#back-to-upgrades').click(function(e) {
         location.reload();
     });

--- a/src/collective/ftw/upgrade/browser/templates/manage_plain.pt
+++ b/src/collective/ftw/upgrade/browser/templates/manage_plain.pt
@@ -88,14 +88,13 @@
 
           <form id="upgrade-form"
                 method="post"
-                target="upgrade-output"
                 tal:define="
                   profiles view/get_data;
                   cyclic_dependencies view/cyclic_dependencies;
                 "
                 tal:condition="not:plone_needs_upgrading"
                 tal:attributes="
-                  action string:${context/absolute_url}/@@manage-upgrades;
+                  action string:${context/absolute_url}/@@upgrade-execute;
                 "
           >
 
@@ -306,9 +305,13 @@
 
           </form>
 
-          <iframe id="upgrade-output"
-                  name="upgrade-output"
-          ></iframe>
+          <div id="upgrade-progress">
+            <div class="upgrade-spinner"></div>
+            <p i18n:translate="">Installing upgrades, please wait...</p>
+          </div>
+          <div id="upgrade-output">
+            <pre id="upgrade-log"></pre>
+          </div>
           <input id="back-to-upgrades"
                  type="button"
                  value="Back"

--- a/src/collective/ftw/upgrade/jsonapi/plonesite.py
+++ b/src/collective/ftw/upgrade/jsonapi/plonesite.py
@@ -204,22 +204,26 @@ class PloneSiteAPI(APIView):
 
         executioner = IExecutioner(self.portal_setup)
         try:
-            with ResponseLogger(self.request.RESPONSE, annotate_result=True):
+            with ResponseLogger(annotate_result=True) as logger:
                 executioner.install_upgrades_by_api_ids(
                     *api_ids,
                     propose_deferrable=propose_deferrable,
                     intermediate_commit=intermediate_commit,
                 )
         except Exception as exc:
+            self.request.RESPONSE.setBody(logger.get_output())
             raise AbortTransactionWithStreamedResponse(exc)
+        return logger.get_output()
 
     def _install_profiles(self, *profile_ids, **options):
         executioner = IExecutioner(self.portal_setup)
         try:
-            with ResponseLogger(self.request.RESPONSE, annotate_result=True):
+            with ResponseLogger(annotate_result=True) as logger:
                 executioner.install_profiles_by_profile_ids(*profile_ids, **options)
         except Exception as exc:
+            self.request.RESPONSE.setBody(logger.get_output())
             raise AbortTransactionWithStreamedResponse(exc)
+        return logger.get_output()
 
     def _require_up_to_date_plone_site(self):
         portal_migration = get_portal_migration(self.context)


### PR DESCRIPTION
This was no longer happening because the streamed output no longer worked with wsgi. 

New implementation:

After clicking install:
<img width="1404" height="714" alt="Screenshot 2026-02-12 at 10 24 36 AM" src="https://github.com/user-attachments/assets/eb55dbf7-68f8-4464-81d1-7f429afb9f0e" />


Progress/Spinner appears
<img width="1234" height="326" alt="Screenshot 2026-02-12 at 10 46 38 AM" src="https://github.com/user-attachments/assets/c2c1b207-0669-4635-a5b9-78a482a34cff" />

Once done, the collected result from logs is displayed

<img width="1376" height="515" alt="Screenshot 2026-02-12 at 10 24 42 AM" src="https://github.com/user-attachments/assets/6c10f4c3-adde-4791-98b5-0d06e9feb9e4" />


Further:
- I removed the response stream implementation completely because it didn't work anymore. The handler was waiting for the last byte anyway and returned the result. 