### PR TITLE
Allow to use the upgrade script in non buildout environments

### DIFF
--- a/news/22.feature.1.md
+++ b/news/22.feature.1.md
@@ -1,0 +1,3 @@
+Allow to specify the directory that stores the authentication file
+with the `UPGRADE_TEMPFILE_AUTH_DIR` environment variable.
+This helps when using the package in non buildout installed Plone sites.

--- a/news/22.feature.md
+++ b/news/22.feature.md
@@ -1,0 +1,2 @@
+Allow to specify the zope  URL using the `UPGRADE_ZOPE_URL` environment variable.
+This helps when using the package in non buildout installed Plone sites.

--- a/src/collective/ftw/upgrade/command/__init__.py
+++ b/src/collective/ftw/upgrade/command/__init__.py
@@ -49,7 +49,13 @@ instance must be running, where "ftw.upgrade" is available and the \
     The Zope instance is discovered automatically by searching for all \
 "parts/*/etc/zope.conf" files in the buildout directory, looking up \
 the instance port and testing whether the port is bound on localhost.
-If multiple instances are running, the first one running is used.
+    If multiple instances are running, the first one running is used.
+
+    If you are not using buildout, \
+or if the instance discovery does not work for some reason, \
+or if if you want to specify a custom URL, \
+you can set the environment variable "UPGRADE_ZOPE_URL" \
+to the URL of your instance, for example "http://localhost:8080/".
 
 {t.bold}AUTHENTICATION:{t.normal}
     There are three authentication options which are tested and used in this \
@@ -88,6 +94,13 @@ named "system-upgrade". The user has a random password. All requests are \
 then authenticated with this user.
     The temporary file is written to \
 [buildout-directory]var/ftw.upgrade-authentication
+
+    If you are not using buildout, \
+or if you want to specify a custom directory for the \
+temporary file, \
+you can set the environment variable "UPGRADE_TEMPFILE_AUTH_DIR" \
+to the absolute or relative path of the directory where the temporary file \
+should be created, for example "/var/run/ftw.upgrade-authentication".
 
 {t.bold}VIRTUAL HOSTING:{t.normal}
     For some upgrade steps it is important that "absolute_url()" returns a \

--- a/src/collective/ftw/upgrade/command/jsonapi.py
+++ b/src/collective/ftw/upgrade/command/jsonapi.py
@@ -226,7 +226,12 @@ def extend_url_with_virtualhost_config(zope_url, public_url, site):
     return url
 
 
-def get_zope_url(instance_name=None):
+def get_zope_url(instance_name=None) -> str:
+    zope_url = os.environ.get("UPGRADE_ZOPE_URL", None)
+    if zope_url:
+        if not zope_url.endswith("/"):
+            zope_url += "/"
+        return zope_url
     instance = get_running_instance(Path.cwd(), instance_name)
     if not instance:
         raise NoRunningInstanceFound()

--- a/src/collective/ftw/upgrade/utils.py
+++ b/src/collective/ftw/upgrade/utils.py
@@ -355,11 +355,13 @@ def subject_from_docstring(docstring):
     return " ".join(lines).strip()
 
 
-def get_tempfile_authentication_directory(directory=None):
+def get_tempfile_authentication_directory(directory=None) -> Path:
     """Finds the buildout directory and returns the absolute path to the
     relative directory var/ftw.upgrade-authentication/.
     If the directory does not exist it is created.
     """
+    if os.environ.get("UPGRADE_TEMPFILE_AUTH_DIR", None):
+        return Path(os.environ["UPGRADE_TEMPFILE_AUTH_DIR"])
     directory = Path(directory) or Path.cwd()
     if not directory.joinpath("bin", "buildout").is_file():
         return get_tempfile_authentication_directory(directory.parent)


### PR DESCRIPTION
Allow to specify the directory that stores the authentication file with the `UPGRADE_TEMPFILE_AUTH_DIR` environment variable.

Allow to specify the zope  URL using the `UPGRADE_ZOPE_URL` environment variable.

Fixes. https://github.com/collective/collective.ftw.upgrade/issues/22